### PR TITLE
Few changes to Discord API endpoints

### DIFF
--- a/mittab/apps/tab/discord_views.py
+++ b/mittab/apps/tab/discord_views.py
@@ -42,25 +42,25 @@ class RoundSerializer(serializers.HyperlinkedModelSerializer):
                   'room']
 
 
-class DebaterViewSet(viewsets.ModelViewSet):
+class DebaterViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Debater.objects.all()
     serializer_class = DebaterSerializer
     filterset_fields = ['name', 'discord_id']
 
 
-class JudgeViewSet(viewsets.ModelViewSet):
+class JudgeViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Judge.objects.all()
     serializer_class = JudgeSerializer
     filterset_fields = ['name', 'discord_id']
 
 
-class RoomViewSet(viewsets.ModelViewSet):
+class RoomViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Room.objects.all()
     serializer_class = RoomSerializer
     filterset_fields = ['name']
 
 
-class RoundViewSet(viewsets.ModelViewSet):
+class RoundViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Round.objects.all()
     serializer_class = RoundSerializer
     filterset_fields = ['round_number']

--- a/mittab/apps/tab/discord_views.py
+++ b/mittab/apps/tab/discord_views.py
@@ -5,26 +5,26 @@ from rest_framework import routers, serializers, viewsets
 class DebaterSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Debater
-        fields = ['name', 'discord_id']
+        fields = ['id', 'name', 'discord_id']
 
 
 class JudgeSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Judge
-        fields = ['name', 'discord_id', 'ballot_code']
+        fields = ['id', 'name', 'discord_id', 'ballot_code']
 
 
 class RoomSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Room
-        fields = ['name']
+        fields = ['id', 'name']
 
 
 class TeamSerializer(serializers.HyperlinkedModelSerializer):
     debaters = DebaterSerializer(many=True, read_only=True)
     class Meta:
         model = Team
-        fields = ['name', 'debaters']
+        fields = ['id', 'name', 'debaters']
 
 
 class RoundSerializer(serializers.HyperlinkedModelSerializer):


### PR DESCRIPTION
* Restricted methods available to the viewpoints (security)
* Pass object IDs to endpoints (better for storage/id than names)

Passing names may not actually be necessary if unused/replaced with numerical IDs.